### PR TITLE
Changed Internet connectivity check to ping libplctag.github.io instead of Google DNS server

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,7 +44,7 @@ android {
         def libplctagFolderPath = "$rootDir/external_src/c/libplctag"
         def libplctagFolder = new File(libplctagFolderPath)
 
-        Process process = Runtime.getRuntime().exec("ping 8.8.8.8"); // Google DNS server
+        Process process = Runtime.getRuntime().exec("ping libplctag.github.io");
         int isReachable = process.waitFor();
 
         // if it does not exist, then clone the repo.


### PR DESCRIPTION
Since ping is processed with every gradle build, this might be less intrusive than pinging the Google DNS server.